### PR TITLE
fix: wrap start/stop with try/catch

### DIFF
--- a/src/ForegroundService.java
+++ b/src/ForegroundService.java
@@ -13,13 +13,17 @@ import android.annotation.TargetApi;
 public class ForegroundService extends Service {
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
-        if (intent.getAction().equals("start")) {
-            // Start the service
-            startPluginForegroundService(intent.getExtras());
-        } else {
-            // Stop the service
-            stopForeground(true);
-            stopSelf();
+        try {
+            if (intent.getAction().equals("start")) {
+                // Start the service
+                startPluginForegroundService(intent.getExtras());
+            } else {
+                // Stop the service
+                stopForeground(true);
+                stopSelf();
+            }
+        } catch (Exception e) {
+            Log.e("#ForegroundService#", e.toString());
         }
 
         return START_STICKY;
@@ -31,7 +35,11 @@ public class ForegroundService extends Service {
 
         // Delete notification channel if it already exists
         NotificationManager manager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
-        manager.deleteNotificationChannel("foreground.service.channel");
+        try {
+          manager.deleteNotificationChannel("foreground.service.channel");
+        } catch (Exception e) {
+          Log.e("#ForegroundService#", e.toString());
+        }
 
         // Get notification channel importance
         Integer importance;
@@ -61,6 +69,10 @@ public class ForegroundService extends Service {
 
         // Get notification icon
         int icon = getResources().getIdentifier((String) extras.get("icon"), "drawable", context.getPackageName());
+
+        if (icon == 0) {
+            icon = getResources().getIdentifier((String) extras.get("icon"), "mipmap", context.getPackageName());
+        }
 
         // Make notification
         Notification notification = new Notification.Builder(context, "foreground.service.channel")


### PR DESCRIPTION
Prevent app crashes on start stop plugin.
Try to get icon from mipmap if drawable unavailable on some devices.
<img width="1229" alt="Screenshot 2021-08-31 at 09 45 05" src="https://user-images.githubusercontent.com/4409473/131455152-5d4904f3-ee76-4f2d-9eda-68b40af9b57e.png">
